### PR TITLE
feat: ohos updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ ohos-sys-opaque-types = { version = "0.1.7" }
 ohos-qos-sys = { version = "0.0.1", features = ["api-20"] }
 ohos-native-window-sys = { version = "0.0.1" }
 ohos-native-buffer-sys = { version = "0.0.1" }
+ohos-init-binding = { version = "0.0.3" }
 
 [target.'cfg(target_env = "ohos")'.build-dependencies]
 napi-build-ohos = { version = "1.1.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,9 @@ napi-ohos = { version = "1.1.3", default-features = false, features = [
     "async",
 ] }
 napi-derive-ohos = { version = "1.1.3" }
-ohos-hilog-binding = { version = "0.1.2" }
+ohos-hilog-binding = { version = "0.1.2", features = [
+    "redirect"
+] }
 xcomponent-sys = { version = "0.3.4", features = ["api-14", "keyboard-types"] }
 keyboard-types = "0.8.3"
 ohos-xcomponent-sys = { version = "0.0.2" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ use napi_derive_ohos::napi;
 #[cfg(target_env = "ohos")]
 use napi_ohos::{bindgen_prelude::Object, Env, Result};
 
+#[cfg(target_env = "ohos")]
+use ohos_hilog_binding::forward_stdio_to_hilog;
+
 #[cfg(feature = "log-impl")]
 pub mod log;
 
@@ -23,8 +26,6 @@ mod default_icon;
 pub use native::{gl, NativeDisplay};
 
 pub use graphics::GraphicsContext as Context;
-#[cfg(target_env = "ohos")]
-use ohos_hilog_binding::forward_stdio_to_hilog;
 
 pub mod date {
     #[cfg(not(target_arch = "wasm32"))]
@@ -259,6 +260,7 @@ static mut OHOS_ENV: Option<Env> = None;
 #[cfg(target_env = "ohos")]
 #[napi(module_exports)] //ignore this error ,this is a napi bug.
 pub fn init(exports: Object, env: Env) -> Result<()> {
+    let _handle = forward_stdio_to_hilog();
     unsafe {
         let mut cpuset: libc::cpu_set_t = std::mem::zeroed();
         libc::CPU_ZERO(&mut cpuset);
@@ -268,7 +270,6 @@ pub fn init(exports: Object, env: Env) -> Result<()> {
             libc::CPU_SET(cpu, &mut cpuset);
         }
         libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &cpuset);
-        let _handle = forward_stdio_to_hilog();
         OHOS_EXPORTS = Some(std::mem::transmute(exports));
         OHOS_ENV = Some(env);
         quad_main();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,14 @@ static mut OHOS_ENV: Option<Env> = None;
 #[napi(module_exports)] //ignore this error ,this is a napi bug.
 pub fn init(exports: Object, env: Env) -> Result<()> {
     unsafe {
+        let mut cpuset: libc::cpu_set_t = std::mem::zeroed();
+        libc::CPU_ZERO(&mut cpuset);
+        let num_cpus = libc::sysconf(libc::_SC_NPROCESSORS_ONLN) as usize;
+        let start_cpu = num_cpus.saturating_sub(4);
+        for cpu in start_cpu..num_cpus {
+            libc::CPU_SET(cpu, &mut cpuset);
+        }
+        libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &cpuset);
         let _handle = forward_stdio_to_hilog();
         OHOS_EXPORTS = Some(std::mem::transmute(exports));
         OHOS_ENV = Some(env);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ mod default_icon;
 pub use native::{gl, NativeDisplay};
 
 pub use graphics::GraphicsContext as Context;
+#[cfg(target_env = "ohos")]
+use ohos_hilog_binding::forward_stdio_to_hilog;
 
 pub mod date {
     #[cfg(not(target_arch = "wasm32"))]
@@ -258,6 +260,7 @@ static mut OHOS_ENV: Option<Env> = None;
 #[napi(module_exports)] //ignore this error ,this is a napi bug.
 pub fn init(exports: Object, env: Env) -> Result<()> {
     unsafe {
+        let _handle = forward_stdio_to_hilog();
         OHOS_EXPORTS = Some(std::mem::transmute(exports));
         OHOS_ENV = Some(env);
         quad_main();

--- a/src/native/ohos.rs
+++ b/src/native/ohos.rs
@@ -597,7 +597,16 @@ pub fn load_file<F: Fn(crate::fs::Response) + 'static>(path: &str, on_loaded: F)
 
 fn load_file_sync(path: &str) -> crate::fs::Response {
     let full_path = format!("/data/storage/el1/bundle/entry/resources/resfile/{}", path);
-    std::fs::read(&full_path).map_err(Into::into)
+    match std::fs::read(&full_path) {
+        Ok(data) => Ok(data),
+        Err(e) => {
+            hilog_error!(format!(
+                "load_file_sync: failed to load file: {} - error: {:?}",
+                full_path, e
+            ));
+            Err(e.into())
+        }
+    }
 }
 
 #[napi]

--- a/src/native/ohos.rs
+++ b/src/native/ohos.rs
@@ -5,6 +5,7 @@ use crate::{
     GraphicsContext,
 };
 use ohos_hilog_binding::{hilog_error, hilog_fatal, hilog_info};
+use ohos_init_binding::canIUse;
 use ohos_input_sys::input_manager::*;
 use ohos_native_buffer_sys::OH_NativeBuffer_Usage_NATIVEBUFFER_USAGE_CPU_READ;
 use ohos_native_window_sys::{
@@ -27,7 +28,14 @@ use napi_ohos::{
     bindgen_prelude::*,
     threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
-use std::{cell::RefCell, sync::mpsc, sync::OnceLock, thread};
+use std::{
+    cell::RefCell,
+    sync::atomic::{AtomicBool, Ordering},
+    sync::mpsc,
+    sync::OnceLock,
+    thread,
+};
+static IS_2IN1_DEVICE: AtomicBool = AtomicBool::new(false);
 static REQUEST_CALLBACK: OnceLock<
     ThreadsafeFunction<String, (), String, napi_ohos::Status, false, false, 1>,
 > = OnceLock::new();
@@ -333,6 +341,7 @@ where
     let xcomponent = XComponent::init(*env, *exports).expect("Failed to initialize XComponent");
     let _ = register_xcomponent_callbacks(&xcomponent);
     set_display_sync(&xcomponent);
+    save_2in1_device();
     struct SendHack<F>(F);
     unsafe impl<F> Send for SendHack<F> {}
     let f = SendHack(f);
@@ -579,12 +588,29 @@ unsafe extern "C" fn touch_event_callback(touch_event: *const Input_TouchEvent) 
 }
 
 unsafe extern "C" fn mouse_event_callback(mouse_event: *const Input_MouseEvent) {
+    // in fact we disable mouse support for normal devices
+    // according to Huawei AGC, we must send the mouse event when the device is '2in1'
+    if !IS_2IN1_DEVICE.load(Ordering::Relaxed) {
+        return;
+    }
     if !mouse_event.is_null() {
-        unsafe {
-            let _action = OH_Input_GetMouseEventAction(mouse_event);
-            let _x = OH_Input_GetMouseEventDisplayX(mouse_event);
-            let _y = OH_Input_GetMouseEventDisplayY(mouse_event);
-        }
+        let action = Input_MouseEventAction(OH_Input_GetMouseEventAction(mouse_event) as u32);
+        let x = OH_Input_GetMouseEventDisplayX(mouse_event);
+        let y = OH_Input_GetMouseEventDisplayY(mouse_event);
+        let action_time = OH_Input_GetMouseEventActionTime(mouse_event);
+        let phase = match action {
+            Input_MouseEventAction::MOUSE_ACTION_BUTTON_DOWN => TouchPhase::Started,
+            Input_MouseEventAction::MOUSE_ACTION_MOVE => TouchPhase::Moved,
+            Input_MouseEventAction::MOUSE_ACTION_BUTTON_UP => TouchPhase::Ended,
+            _ => TouchPhase::Cancelled,
+        };
+        send_message(Message::Touch {
+            phase,
+            touch_id: 0,
+            x: x as f32,
+            y: y as f32,
+            time: (action_time / 1000) as u64,
+        });
     }
 }
 
@@ -626,4 +652,11 @@ pub fn call_request_callback(value: String) {
     } else {
         hilog_error!("REQUEST_CALLBACK not initialized");
     }
+}
+
+pub fn save_2in1_device() {
+    // ref:https://developer.huawei.com/consumer/cn/doc/harmonyos-references/js-apis-huksexternalcrypto
+    // this Capability only shows true in 2in1 device.
+    let is_2in1 = canIUse("SystemCapability.Security.Huks.CryptoExtension");
+    IS_2IN1_DEVICE.store(is_2in1, Ordering::Relaxed);
 }

--- a/src/native/ohos.rs
+++ b/src/native/ohos.rs
@@ -30,7 +30,7 @@ use napi_ohos::{
 };
 use std::{
     cell::RefCell,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     sync::mpsc,
     sync::OnceLock,
     thread,

--- a/src/native/ohos.rs
+++ b/src/native/ohos.rs
@@ -35,8 +35,9 @@ use std::{
     sync::OnceLock,
     thread,
 };
+
 static IS_2IN1_DEVICE: AtomicBool = AtomicBool::new(false);
-static INTERCEPTOR_REGISTERED: AtomicBool = AtomicBool::new(false);
+static INTERCEPTOR: AtomicUsize = AtomicUsize::new(0);
 static REQUEST_CALLBACK: OnceLock<
     ThreadsafeFunction<String, (), String, napi_ohos::Status, false, false, 1>,
 > = OnceLock::new();
@@ -514,7 +515,7 @@ where
         Ok(())
     });
     xcomponent.on_touch_event(|_xcomponent, _win, data| {
-        if INTERCEPTOR_REGISTERED.load(Ordering::Relaxed) {
+        if INTERCEPTOR.load(Ordering::Acquire) != 0 {
             return Ok(());
         }
         for i in 0..data.num_points {
@@ -547,7 +548,7 @@ where
 #[napi]
 pub fn set_interceptor_state(state: bool) -> bool {
     if state {
-        if INTERCEPTOR_REGISTERED.load(Ordering::Relaxed) {
+        if INTERCEPTOR.load(Ordering::Acquire) != 0 {
             hilog_info!("Interceptor already registered");
             call_request_callback(r#"{"action":"interceptor_state","state":true}"#.to_string());
             return true;
@@ -557,8 +558,9 @@ pub fn set_interceptor_state(state: bool) -> bool {
             touchCallback: Some(touch_event_callback),
             axisCallback: Some(axis_event_callback),
         });
+        let callback = Box::into_raw(callback);
         unsafe {
-            let ret = OH_Input_AddInputEventInterceptor(Box::leak(callback), std::ptr::null_mut());
+            let ret = OH_Input_AddInputEventInterceptor(callback, std::ptr::null_mut());
             if ret.is_err() {
                 hilog_info!("add input Event Interceptor failed , ret: {:?}", ret);
                 call_request_callback(
@@ -567,15 +569,18 @@ pub fn set_interceptor_state(state: bool) -> bool {
                 return false;
             }
         }
-        INTERCEPTOR_REGISTERED.store(true, Ordering::Relaxed);
+        INTERCEPTOR.store(callback as usize, Ordering::Release);
         hilog_info!("Interceptor registered successfully");
         call_request_callback(r#"{"action":"interceptor_state","state":true}"#.to_string());
     } else {
-        if INTERCEPTOR_REGISTERED.load(Ordering::Relaxed) {
+        let prev = INTERCEPTOR.swap(0, Ordering::AcqRel);
+        if prev != 0 {
             unsafe {
                 let _ = OH_Input_RemoveInputEventInterceptor();
             }
-            INTERCEPTOR_REGISTERED.store(false, Ordering::Relaxed);
+            unsafe {
+                Box::from_raw(prev as *mut Input_InterceptorEventCallback);
+            }
             hilog_info!("Interceptor removed, falling back to on_touch_event");
         }
         call_request_callback(r#"{"action":"interceptor_state","state":false}"#.to_string());
@@ -585,6 +590,9 @@ pub fn set_interceptor_state(state: bool) -> bool {
 
 #[no_mangle]
 unsafe extern "C" fn touch_event_callback(touch_event: *const Input_TouchEvent) {
+    if INTERCEPTOR.load(Ordering::Acquire) == 0 {
+        return;
+    }
     if !touch_event.is_null() {
         let action = OH_Input_GetTouchEventAction(touch_event);
         let x = OH_Input_GetTouchEventDisplayX(touch_event);
@@ -608,6 +616,9 @@ unsafe extern "C" fn touch_event_callback(touch_event: *const Input_TouchEvent) 
 }
 
 unsafe extern "C" fn mouse_event_callback(mouse_event: *const Input_MouseEvent) {
+    if INTERCEPTOR.load(Ordering::Acquire) == 0 {
+        return;
+    }
     // in fact we disable mouse support for normal devices
     // according to Huawei AGC, we must send the mouse event when the device is '2in1'
     if !IS_2IN1_DEVICE.load(Ordering::Relaxed) {

--- a/src/native/ohos.rs
+++ b/src/native/ohos.rs
@@ -36,6 +36,7 @@ use std::{
     thread,
 };
 static IS_2IN1_DEVICE: AtomicBool = AtomicBool::new(false);
+static INTERCEPTOR_REGISTERED: AtomicBool = AtomicBool::new(false);
 static REQUEST_CALLBACK: OnceLock<
     ThreadsafeFunction<String, (), String, napi_ohos::Status, false, false, 1>,
 > = OnceLock::new();
@@ -512,37 +513,45 @@ where
         send_message(Message::SurfaceDestroyed);
         Ok(())
     });
-    if !set_interceptor_state(true) {
-        hilog_info!("falling back to touch event.");
-        xcomponent.on_touch_event(|_xcomponent, _win, data| {
-            for i in 0..data.num_points {
-                let touch_point = &data.touch_points[i as usize];
-                let phase = match touch_point.event_type {
-                    ohos_xcomponent_binding::TouchEvent::Down => TouchPhase::Started,
-                    ohos_xcomponent_binding::TouchEvent::Up => TouchPhase::Ended,
-                    ohos_xcomponent_binding::TouchEvent::Move => TouchPhase::Moved,
-                    ohos_xcomponent_binding::TouchEvent::Cancel => TouchPhase::Cancelled,
-                    _ => TouchPhase::Cancelled, // Default to cancelled for unknown events
-                };
-                send_message(Message::Touch {
-                    phase,
-                    touch_id: touch_point.id as u64,
-                    x: touch_point.x,
-                    y: touch_point.y,
-                    time: (touch_point.timestamp / 1_000_000) as u64,
-                });
-            }
-            Ok(())
-        });
-    }
+    xcomponent.on_touch_event(|_xcomponent, _win, data| {
+        if INTERCEPTOR_REGISTERED.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        for i in 0..data.num_points {
+            let touch_point = &data.touch_points[i as usize];
+            let phase = match touch_point.event_type {
+                ohos_xcomponent_binding::TouchEvent::Down => TouchPhase::Started,
+                ohos_xcomponent_binding::TouchEvent::Up => TouchPhase::Ended,
+                ohos_xcomponent_binding::TouchEvent::Move => TouchPhase::Moved,
+                ohos_xcomponent_binding::TouchEvent::Cancel => TouchPhase::Cancelled,
+                _ => TouchPhase::Cancelled, // Default to cancelled for unknown events
+            };
+            send_message(Message::Touch {
+                phase,
+                touch_id: touch_point.id as u64,
+                x: touch_point.x,
+                y: touch_point.y,
+                time: (touch_point.timestamp / 1_000_000) as u64,
+            });
+        }
+        Ok(())
+    });
+    //if !set_interceptor_state(true) {
+    //    hilog_info!("Interceptor registration failed, using on_touch_event fallback.");
+    //}
 
     let _ = xcomponent.register_callback();
     let _ = xcomponent.on_frame_callback(|_, _, _| Ok(()));
 }
 
 #[napi]
-fn set_interceptor_state(state: bool) -> bool {
+pub fn set_interceptor_state(state: bool) -> bool {
     if state {
+        if INTERCEPTOR_REGISTERED.load(Ordering::Relaxed) {
+            hilog_info!("Interceptor already registered");
+            call_request_callback(r#"{"action":"interceptor_state","state":true}"#.to_string());
+            return true;
+        }
         let callback = Box::new(Input_InterceptorEventCallback {
             mouseCallback: Some(mouse_event_callback),
             touchCallback: Some(touch_event_callback),
@@ -552,13 +561,22 @@ fn set_interceptor_state(state: bool) -> bool {
             let ret = OH_Input_AddInputEventInterceptor(Box::leak(callback), std::ptr::null_mut());
             if ret.is_err() {
                 hilog_info!("add input Event Interceptor failed , ret: {:?}", ret);
+                call_request_callback(r#"{"action":"interceptor_state","state":false}"#.to_string());
                 return false;
             }
         }
+        INTERCEPTOR_REGISTERED.store(true, Ordering::Relaxed);
+        hilog_info!("Interceptor registered successfully");
+        call_request_callback(r#"{"action":"interceptor_state","state":true}"#.to_string());
     } else {
-        unsafe {
-            let _ = OH_Input_RemoveInputEventInterceptor();
+        if INTERCEPTOR_REGISTERED.load(Ordering::Relaxed) {
+            unsafe {
+                let _ = OH_Input_RemoveInputEventInterceptor();
+            }
+            INTERCEPTOR_REGISTERED.store(false, Ordering::Relaxed);
+            hilog_info!("Interceptor removed, falling back to on_touch_event");
         }
+        call_request_callback(r#"{"action":"interceptor_state","state":false}"#.to_string());
     }
     return true;
 }

--- a/src/native/ohos.rs
+++ b/src/native/ohos.rs
@@ -561,7 +561,9 @@ pub fn set_interceptor_state(state: bool) -> bool {
             let ret = OH_Input_AddInputEventInterceptor(Box::leak(callback), std::ptr::null_mut());
             if ret.is_err() {
                 hilog_info!("add input Event Interceptor failed , ret: {:?}", ret);
-                call_request_callback(r#"{"action":"interceptor_state","state":false}"#.to_string());
+                call_request_callback(
+                    r#"{"action":"interceptor_state","state":false}"#.to_string(),
+                );
                 return false;
             }
         }


### PR DESCRIPTION
log redirect, better handle file, and set affinity using `libc`.

about touch: When not in game ,it will default mode to ArkUI touch. When going to game scene, set `set_interceptor_state` to true to enhance input.

we disallow mouses to touch in game scene ,except for huawei computer (2in1),I used a feature parameter to judge if 2in1.

in hilog-rs, there was a function that enables forward all stdio log to ohos, set it early to get all logs.

in `sched_setaffinity`, set main cores on last 4 cores can make ffmpeg performance better, and better fps